### PR TITLE
feat: add download button for raw markdown source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MarkSight
 
-An open source markdown editor with real-time preview, a smart formatting toolbar, keyboard shortcuts, a document outline, and HTML/PDF export.
+An open source markdown editor with real-time preview, a smart formatting toolbar, keyboard shortcuts, a document outline, and Markdown/HTML/PDF export.
 
 🔗 **Live:** [marksight.laramateo.com](https://marksight.laramateo.com)
 
@@ -10,7 +10,7 @@ An open source markdown editor with real-time preview, a smart formatting toolba
 - **Smart toolbar** — context-aware formatting that detects and toggles existing markdown
 - **Keyboard shortcuts** — bold (⌘B), italic (⌘I), strikethrough (⌘U), link (⌘K), inline code (⌘`), headings (⌘⇧1–3), lists, and more
 - **Document outline** — auto-generated, clickable heading navigation that scrolls the preview
-- **Export** — download styled HTML or print to PDF; preview the HTML in a new tab
+- **Export** — download the raw Markdown source or styled HTML, print to PDF, or preview the HTML in a new tab
 - **GitHub-flavored markdown** — tables, task lists, strikethrough (via `remark-gfm`)
 - **Syntax highlighting** — fenced code blocks rendered with Prism
 - **Light / dark theme** — system-aware, persisted across sessions

--- a/src/components/export-toolbar.tsx
+++ b/src/components/export-toolbar.tsx
@@ -5,7 +5,7 @@ import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Progress } from "@/components/ui/progress";
-import { Download, FileText, Printer, ExternalLink } from "lucide-react";
+import { Download, FileDown, FileText, Printer, ExternalLink } from "lucide-react";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkHtml from "remark-html";
@@ -235,6 +235,10 @@ export function ExportToolbar({ content, filename = "document" }: ExportToolbarP
     }
   }
 
+  function downloadMarkdown() {
+    downloadFile(content, `${filename}.md`, 'text/markdown');
+  }
+
   const exportButtons = [
     {
       icon: FileText,
@@ -253,6 +257,12 @@ export function ExportToolbar({ content, filename = "document" }: ExportToolbarP
       label: "Preview HTML",
       action: previewHTML,
       shortcut: "⌘⇧P",
+    },
+    {
+      icon: FileDown,
+      label: "Download Markdown",
+      action: downloadMarkdown,
+      shortcut: "⌘⇧S",
     },
   ];
 


### PR DESCRIPTION
## Description

Adds a fourth button to the export toolbar that downloads the current document
as a raw `.md` file. The export toolbar already supported styled HTML, PDF, and
HTML preview, but there was no way to save the markdown source itself — since
the document only lives in localStorage, users had no first-class way to keep an
editable copy of their work.

The button reuses the existing `downloadFile` helper and follows the established
`exportButtons` array pattern, so no new dependencies or extra plumbing are
needed. The filename follows the existing convention (`marksight-document.md`).

## Related issue

Closes #21 

## Type of change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Screenshots / recording

### Before
<img width="1838" height="968" alt="before" src="https://github.com/user-attachments/assets/cb8e697c-2994-4ac7-ad0f-75f81b307e60" />

### After
<img width="1838" height="968" alt="after" src="https://github.com/user-attachments/assets/6deb77c3-7613-42b5-ba99-94e2d40fbe91" />



## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] I tested my change in the browser
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I updated docs where relevant <!-- N/A — no docs change needed -->
