### PR TITLE
fix: keep outline sidebar attached at wide viewports (#35)

### DIFF
--- a/src/components/layout-content.tsx
+++ b/src/components/layout-content.tsx
@@ -16,7 +16,7 @@ export function LayoutContent({ children }: LayoutContentProps) {
   const { content } = useContent();
 
   return (
-    <div className="flex min-h-dvh bg-background">
+    <div className="flex min-h-dvh w-full bg-background">
       <SidebarInset className="flex-1">
         <header className="sticky top-0 z-50 flex items-center justify-between px-4 py-4 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## What

Adds `w-full` to the layout wrapper in `LayoutContent` so the right-hand Document Outline sidebar stays attached to the main content at wide viewports.

Fixes #35

## Why

`SidebarProvider` is `flex w-full` and shadcn's sidebar expects `<AppSidebar>` + `<SidebarInset>` to fill the row so the sidebar's in-flow "gap" stays aligned with its `position: fixed` panel. `LayoutContent` inserted an extra flex wrapper with no `w-full`/`flex-1`, so — as the provider's only flex child — it defaulted to `flex: 0 1 auto` and shrank to its content width. The reserved gap then decoupled from the actual panel: on wide windows the editor/preview got squished and the sidebar floated against the far-right edge with a dead band before it.

## The change

```diff
- <div className="flex min-h-dvh bg-background">
+ <div className="flex min-h-dvh w-full bg-background">
```

`src/components/layout-content.tsx` — one line.

## Verification

Measured live (Document Outline gap vs. its `fixed` panel):

| viewport | layout div | inset (main content) | gap ↔ panel offset |
|---|---|---|---|
| 2560px **before** | 1734px | 1414px (squished) | **816px** ✗ |
| 2560px **after** | 2550px (full) | 2230px (fills) | **0px** ✓ |

No horizontal page overflow; panel fully visible. The `w-full` is a no-op at normal widths (the content already filled the row there), so narrow/standard layouts are unchanged.