### PR TITLE
fix: scope keyboard shortcuts to focused editor

### DIFF
--- a/src/components/markdown-toolbar.tsx
+++ b/src/components/markdown-toolbar.tsx
@@ -459,11 +459,26 @@ export function MarkdownToolbar({ onInsert, getCurrentContext }: MarkdownToolbar
   // Keyboard shortcuts
   useEffect(function setupKeyboardShortcuts() {
     function handleKeyDown(event: KeyboardEvent) {
+      if(!document.activeElement?.closest(".cm-editor")) return;
       const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
       const isCtrlOrCmd = isMac ? event.metaKey : event.ctrlKey;
 
       if (!isCtrlOrCmd) return;
+      
+      // physical-key shortcuts 
+      if (event.shiftKey){
+        if (event.code.startsWith("Digit")){
+          const numericKey = Number(event.code.slice(-1));
+          if (numericKey >=1 && numericKey <=3){
+            event.preventDefault();
+            trackShortcut(`Cmd+Shift+${numericKey}`);
+            smartHeading(numericKey);
+            return;
+          }
+        }
+      }
 
+      // character shortcuts 
       switch (event.key.toLowerCase()) {
         case 'b':
           event.preventDefault();
@@ -489,27 +504,6 @@ export function MarkdownToolbar({ onInsert, getCurrentContext }: MarkdownToolbar
           event.preventDefault();
           trackShortcut('Cmd+`');
           smartInsert("`", "`", "code", "code");
-          break;
-        case '1':
-          if (event.shiftKey) {
-            event.preventDefault();
-            trackShortcut('Cmd+Shift+1');
-            smartHeading(1);
-          }
-          break;
-        case '2':
-          if (event.shiftKey) {
-            event.preventDefault();
-            trackShortcut('Cmd+Shift+2');
-            smartHeading(2);
-          }
-          break;
-        case '3':
-          if (event.shiftKey) {
-            event.preventDefault();
-            trackShortcut('Cmd+Shift+3');
-            smartHeading(3);
-          }
           break;
         case 'l':
           if (event.shiftKey) {


### PR DESCRIPTION
<!--
Thanks for contributing to MarkSight! 💛
Please fill out the sections below. Remove any that don't apply.
-->

## Description

This PR scopes keyboard shortcuts so they only trigger when the CodeMirror editor is focused.

It also updates the heading shortcuts (`Ctrl/Cmd+Shift+1`, `2`, `3`) to use `event.code` instead of `event.key`, ensuring they work correctly on keyboard layouts where shifted number keys produce different characters.

## Related issue

Closes #16 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] 🧹 Refactor / chore (no user-facing change)

## Screenshots / recording

No visible UI changes.

## Checklist

- [x] My branch is up to date with `main`
- [ ] `npm run lint` passes*
- [x] `npm run build` succeeds
- [x] I tested my change in the browser
- [x] My commits follow Conventional Commits
- [ ] I updated docs where relevant

\* `npm run lint` reports existing project warnings unrelated to this change. No new lint errors were introduced.