### PR TITLE
feat: add word and character count to editor footer

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -137,6 +137,8 @@ export default function Home() {
   });
   const [previousValue, setPreviousValue] = useState<string>(value);
   const debounced = useDebouncedValue(value, { delayMs: 100 });
+  const charCount = debounced.length;
+  const wordCount = debounced.trim() ? debounced.trim().split(/\s+/).length : 0;
   const { setContent } = useContent();
   const { trackDocumentChange, trackReset, trackClear } = useAnalytics();
 
@@ -221,7 +223,11 @@ export default function Home() {
               <CardContent className="flex min-h-0 flex-1 flex-col">
                 <MarkdownEditor value={value} onChange={handleValueChange} />
               </CardContent>
-              <CardFooter className="flex justify-end">
+              <CardFooter className="flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">
+                  {wordCount} {wordCount === 1 ? "word" : "words"} ·{" "}
+                  {charCount} {charCount === 1 ? "character" : "characters"}
+                </span>
                 <Button
                   variant="outline"
                   size="sm"


### PR DESCRIPTION
## Description

Adds a live word and character count to the Markdown Editor card footer, next to the Clear button. Writers routinely need to know document length (posts, abstracts, assignments with limits), and there was previously no way to see it without pasting the text elsewhere.

The count is derived from the existing debounced document value (the same value that feeds the preview), so it updates as you type without recomputing on every keystroke and adds no new dependencies. It reuses the existing `CardFooter` switching it to `justify-between` so the count sits on the left and the Clear button stays exactly where it was (no layout shift).

Note: counts are naive — markdown syntax characters (`#`, `*`, backticks, etc.) are included in both totals. That's intended for a first version; a markdown-aware count can be a follow-up if wanted.

## Related issue

Closes #24

## Type of change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Screenshots / recording

### Before
<img width="1837" height="963" alt="Screenshot from 2026-07-01 14-06-47" src="https://github.com/user-attachments/assets/11cbe463-419e-4fc0-a11e-9c8f9fe235d5" />

### After 
<img width="1837" height="963" alt="Screenshot from 2026-07-01 14-01-00" src="https://github.com/user-attachments/assets/2bb38833-6fb3-4f9e-8b00-d30645b2d0ac" />

## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] I tested my change in the browser
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I updated docs where relevant <!-- N/A — no documented behavior changed -->
