### PR TITLE
feat: add About page with FAQ schema, community links, and credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ An open source markdown editor with real-time preview, a smart formatting toolba
 
 🔗 **Live:** [marksight.laramateo.com](https://marksight.laramateo.com)
 
+## About
+
+MarkSight is a free, open source markdown editor that runs entirely in your
+browser — no account, no server-side storage. Documents are persisted to
+`localStorage` and exports are generated client-side, so your writing never
+leaves your device. It was created by [Lara Mateo](https://laramateo.com) and
+is developed in the open with the help of community contributors.
+
 ## Features
 
 - **Live preview** — CodeMirror editor with an instantly-rendered preview pane
@@ -84,6 +92,29 @@ to set up the project and submit changes, and please follow our
 
 New here? Look for issues labelled
 [`good first issue`](https://github.com/Rinava/MarkSight/issues?q=is%3Aopen+label%3A%22good+first+issue%22).
+
+## Community
+
+Questions, ideas, or just want to show what you built with MarkSight? Join the
+conversation in [GitHub Discussions](https://github.com/Rinava/MarkSight/discussions).
+For bugs and feature requests, open an
+[issue](https://github.com/Rinava/MarkSight/issues).
+
+## Contributors
+
+Thanks to everyone who has helped make MarkSight better:
+
+<a href="https://github.com/Rinava/MarkSight/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Rinava/MarkSight" alt="MarkSight contributors" />
+</a>
+
+Want to see yourself here? Start with the
+[contributing guide](./CONTRIBUTING.md).
+
+## Author
+
+MarkSight was created and is maintained by
+**[Lara Mateo](https://laramateo.com)** ([@Rinava](https://github.com/Rinava)).
 
 ## License
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,242 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+const SITE_URL = "https://marksight.laramateo.com";
+const GITHUB_URL = "https://github.com/Rinava/MarkSight";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "MarkSight is a free, open source markdown editor created by Lara Mateo. Learn how it keeps your documents private, meet the contributors, and join the community on GitHub.",
+  alternates: {
+    canonical: `${SITE_URL}/about`,
+  },
+  openGraph: {
+    type: "website",
+    url: `${SITE_URL}/about`,
+    siteName: "MarkSight",
+    title: "About MarkSight - Free, Open Source Markdown Editor",
+    description:
+      "The story behind MarkSight: a privacy-friendly, open source markdown editor built by Lara Mateo and community contributors.",
+  },
+};
+
+const faqs = [
+  {
+    question: "Is MarkSight free to use?",
+    answer:
+      "Yes. MarkSight is completely free and open source under the MIT license. There are no accounts, subscriptions, or paid tiers — you can also fork the code on GitHub and adapt it to your needs.",
+  },
+  {
+    question: "Where are my documents stored?",
+    answer:
+      "Your documents never leave your device. MarkSight runs entirely in your browser and saves your work to localStorage automatically. There is no server-side storage and no sign-up.",
+  },
+  {
+    question: "What export formats does MarkSight support?",
+    answer:
+      "You can download your document as raw Markdown (.md), export it as a styled HTML file, print it to PDF, or preview the generated HTML in a new tab. Exports are generated client-side in your browser.",
+  },
+  {
+    question: "Does MarkSight support GitHub-flavored markdown and diagrams?",
+    answer:
+      "Yes. MarkSight supports GitHub-flavored markdown — tables, task lists, and strikethrough — plus syntax-highlighted code blocks and Mermaid diagrams that render live in the preview and in exports.",
+  },
+  {
+    question: "How do I report a bug or suggest a feature?",
+    answer:
+      "Open an issue on the MarkSight GitHub repository for bugs and feature requests, or start a thread in GitHub Discussions for questions and ideas. Pull requests are welcome too.",
+  },
+  {
+    question: "Who makes MarkSight?",
+    answer:
+      "MarkSight was created and is maintained by Lara Mateo, together with open source contributors from the community. Anyone can contribute on GitHub.",
+  },
+];
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "AboutPage",
+      name: "About MarkSight",
+      url: `${SITE_URL}/about`,
+      description:
+        "About MarkSight, a free and open source markdown editor with real-time preview, created by Lara Mateo and community contributors.",
+      about: {
+        "@type": "WebApplication",
+        name: "MarkSight",
+        url: SITE_URL,
+      },
+      author: {
+        "@type": "Person",
+        name: "Lara Mateo",
+        url: "https://laramateo.com",
+      },
+    },
+    {
+      "@type": "FAQPage",
+      mainEntity: faqs.map((faq) => ({
+        "@type": "Question",
+        name: faq.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: faq.answer,
+        },
+      })),
+    },
+    {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "MarkSight", item: SITE_URL },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "About",
+          item: `${SITE_URL}/about`,
+        },
+      ],
+    },
+  ],
+};
+
+function ExternalLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="font-medium text-foreground underline underline-offset-4 hover:text-primary transition-colors"
+    >
+      {children}
+    </Link>
+  );
+}
+
+export default function AboutPage() {
+  return (
+    <div className="h-full overflow-y-auto">
+      {/* JSON-LD is non-executable data, so CSP script-src does not apply. */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),
+        }}
+      />
+      <article className="container mx-auto max-w-3xl px-4 py-8 sm:py-12 space-y-10">
+        <header className="space-y-4">
+          <h1 className="text-3xl font-bold">About MarkSight</h1>
+          <p className="text-muted-foreground">
+            MarkSight is a free, open source markdown editor that runs entirely
+            in your browser. It pairs a CodeMirror editor with an
+            instantly-rendered preview, a smart formatting toolbar, keyboard
+            shortcuts, a document outline, and Markdown, HTML, and PDF export —
+            without accounts, subscriptions, or server-side storage.
+          </p>
+          <p className="text-muted-foreground">
+            Your documents are saved to your browser&apos;s localStorage and
+            exports are generated client-side, so your writing never leaves
+            your device.
+          </p>
+          <Link
+            href="/"
+            className="inline-block font-medium text-primary underline underline-offset-4 hover:no-underline"
+          >
+            Open the editor →
+          </Link>
+        </header>
+
+        <section className="space-y-3">
+          <h2 className="text-2xl font-semibold">A place to talk</h2>
+          <p className="text-muted-foreground">
+            MarkSight is developed in the open, and the conversation happens on
+            GitHub:
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+            <li>
+              <ExternalLink href={`${GITHUB_URL}/discussions`}>
+                GitHub Discussions
+              </ExternalLink>{" "}
+              — ask questions, share what you&apos;re building, or propose
+              ideas.
+            </li>
+            <li>
+              <ExternalLink href={`${GITHUB_URL}/issues`}>
+                GitHub Issues
+              </ExternalLink>{" "}
+              — report bugs and request features.
+            </li>
+            <li>
+              <ExternalLink
+                href={`${GITHUB_URL}/blob/main/CONTRIBUTING.md`}
+              >
+                Contributing guide
+              </ExternalLink>{" "}
+              — everything you need to land your first pull request.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-2xl font-semibold">Contributors</h2>
+          <p className="text-muted-foreground">
+            MarkSight is better because of the people who report bugs, suggest
+            features, and open pull requests. Thank you!
+          </p>
+          <Link
+            href={`${GITHUB_URL}/graphs/contributors`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block"
+          >
+            {/* Third-party dynamic image; next/image adds no value here. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="https://contrib.rocks/image?repo=Rinava/MarkSight"
+              alt="Avatars of MarkSight contributors on GitHub"
+              width={200}
+              height={50}
+              loading="lazy"
+            />
+          </Link>
+          <p className="text-muted-foreground">
+            Want to join them? Look for issues labelled{" "}
+            <ExternalLink
+              href={`${GITHUB_URL}/issues?q=is%3Aopen+label%3A%22good+first+issue%22`}
+            >
+              good first issue
+            </ExternalLink>
+            .
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-2xl font-semibold">Who&apos;s behind it</h2>
+          <p className="text-muted-foreground">
+            MarkSight was created and is maintained by{" "}
+            <ExternalLink href="https://laramateo.com">Lara Mateo</ExternalLink>{" "}
+            (<ExternalLink href="https://github.com/Rinava">@Rinava</ExternalLink>{" "}
+            on GitHub), and developed together with open source contributors
+            from around the world.
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold">Frequently asked questions</h2>
+          {faqs.map((faq) => (
+            <div key={faq.question} className="space-y-1">
+              <h3 className="text-lg font-medium">{faq.question}</h3>
+              <p className="text-muted-foreground">{faq.answer}</p>
+            </div>
+          ))}
+        </section>
+      </article>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,5 +10,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 1,
     },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
   ];
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -24,7 +24,21 @@ export function Footer() {
           </div>
           <div className="flex items-center gap-4">
             <Link
-              href="https://github.com/rinava/MarkSight"
+              href="/about"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              About
+            </Link>
+            <Link
+              href="https://github.com/Rinava/MarkSight/discussions"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Community
+            </Link>
+            <Link
+              href="https://github.com/Rinava/MarkSight"
               target="_blank"
               rel="noopener noreferrer"
               className="text-sm text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## Description

Adds a proper public identity for the project, on the site and in the README, structured so search engines and AI answer engines can index and cite it:

- **New `/about` page** (server-rendered, fully crawlable) with:
  - an intro covering what MarkSight is and its privacy story (client-side only, `localStorage`, no accounts)
  - **A place to talk** — links to GitHub Discussions, Issues, and the contributing guide
  - **Contributors** — auto-updating [contrib.rocks](https://contrib.rocks) avatar grid linked to the contributors graph
  - **Who's behind it** — author/founder credit
  - a six-question FAQ whose visible text exactly mirrors the `FAQPage` JSON-LD
- **Structured data**: `AboutPage`, `FAQPage`, and `BreadcrumbList` JSON-LD served in the page HTML (verified present in the server response), complementing the existing `WebApplication` schema
- **Page metadata**: canonical `/about`, Open Graph tags, and the site title template
- **Footer**: new `About` and `Community` (GitHub Discussions) links on every page; GitHub repo link casing normalized to `Rinava/MarkSight`
- **Sitemap**: `/about` entry added
- **README**: new About, Community, Contributors (contrib.rocks), and Author sections

## Related issue

No issue — motivation is SEO/AEO: give crawlers and AI answer engines a stable, citable URL that answers "what is MarkSight, who makes it, where do I ask questions", and give visitors a place to join the community.

## Type of change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📖 Documentation

## Screenshots / recording

The page renders inside the existing app shell (header, sidebar, footer) in both themes; verified in the browser preview. Live check after merge: `/about`.

## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run lint` passes (0 errors; the 4 warnings are pre-existing in untouched files)
- [x] `npm run build` succeeds (`/about` route generated)
- [x] I tested my change in the browser
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I updated docs where relevant