### PR TITLE
feat: add custom 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-background px-6">
+      <div className="mx-auto flex max-w-lg flex-col items-center text-center">
+        <p className="text-sm font-medium text-muted-foreground">404</p>
+
+        <h1 className="mt-2 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+          Page not found
+        </h1>
+
+        <p className="mt-4 text-base text-muted-foreground">
+          Sorry, we couldn&apos;t find the page you&apos;re looking for. It may
+          have been moved, deleted, or the URL might be incorrect.
+        </p>
+
+        <Button asChild className="mt-8">
+          <Link href="/">Back to MarkSight</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Description

Adds a custom 404 page for the Next.js App Router.

Previously, navigating to an unknown route displayed the default Next.js 404 page, which was unbranded and inconsistent with MarkSight's design. This PR adds `src/app/not-found.tsx` to provide a themed 404 page that matches the application's styling and includes a clear navigation link back to the home page.

## Related issue

Closes #44

## Type of change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that changes existing behavior)
* [ ] 📖 Documentation
* [ ] 🧹 Refactor / chore (no user-facing change)

## Screenshots / recording

*Attached below.*

## Checklist

* [x] My branch is up to date with `main`
* [x] `npm run lint` passes *(existing repository warnings only; no new warnings introduced)*
* [x] `npm run build` succeeds
* [x] I tested my change in the browser
* [x] My commits follow Conventional Commits
* [ ] I updated docs where relevant *(not applicable)*
<img width="1464" height="708" alt="Screenshot 2026-07-04 at 6 10 24 PM" src="https://github.com/user-attachments/assets/3973f7ea-09b5-4ffb-8e3a-973a439364c6" />

