### PR TITLE
fix: remove stale disallow rules from robots.ts

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,11 +1,10 @@
-import { MetadataRoute } from "next";
+import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: ["/private/", "/admin/"],
     },
     sitemap: "https://marksight.laramateo.com/sitemap.xml",
   };


### PR DESCRIPTION
Removes stale disallow rules from src/app/robots.ts. MarkSight is a single-page app with no /private or /admin routes, so these entries protected nothing and needlessly exposed non-existent route names in a public robots.txt.
Changes

Removed disallow: ["/private/", "/admin/"] from the robots rule
Kept userAgent: "*", allow: "/", and the sitemap reference intact

Verification

Ran npm run build and confirmed the generated /robots.txt no longer includes /private/ or /admin/ disallow lines

Closes #47