### PR TITLE
docs: fix documentation drift (Next.js version, renamed middleware, missing paths)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,12 +91,13 @@ node scripts/generate-assets.mjs
 ```
 src/
 ├── app/              # App Router entry (layout, page, metadata, route assets)
+│   └── api/          # route handlers (MCP server, AI skill improvement)
 ├── components/       # UI components (editor, preview, toolbar, sidebar, …)
 │   └── ui/           # shadcn/ui primitives — avoid hand-editing; re-add via the CLI
 ├── contexts/         # React context providers
 ├── hooks/            # custom hooks
 ├── lib/              # utilities (slugify, local storage, syntax highlighter, …)
-└── middleware.ts     # security headers / CSP
+└── proxy.ts          # security headers / CSP
 ```
 
 ## Coding guidelines

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ graph LR
 
 ## Tech stack
 
-- [Next.js 15](https://nextjs.org/) (App Router) + [React 19](https://react.dev/)
+- [Next.js 16](https://nextjs.org/) (App Router) + [React 19](https://react.dev/)
 - [Tailwind CSS v4](https://tailwindcss.com/) + [shadcn/ui](https://ui.shadcn.com/) primitives
 - [CodeMirror](https://codemirror.net/) (`@uiw/react-codemirror`) for editing
 - [react-markdown](https://github.com/remarkjs/react-markdown) + `remark-gfm` for rendering
@@ -128,11 +128,13 @@ metadata images (`src/app/apple-icon.png`, `opengraph-image.png`, `twitter-image
 ```
 src/
 ├── app/              # App Router entry (layout, page, metadata, route assets)
+│   └── api/          # route handlers (MCP server, AI skill improvement)
 ├── components/       # UI components (editor, preview, toolbar, sidebar, …)
 │   └── ui/           # shadcn/ui primitives
 ├── contexts/         # React context providers
 ├── hooks/            # custom hooks
-└── lib/              # utilities (slugify, local storage, syntax highlighter, …)
+├── lib/              # utilities (slugify, local storage, syntax highlighter, …)
+└── proxy.ts          # security headers / CSP
 ```
 
 ## Contributing


### PR DESCRIPTION
Fixes documentation that had drifted from the code.

## Changes

**README.md**
- Tech stack: `Next.js 15` → `Next.js 16` (matches `next@16.2.9` in `package.json`; React 19 was already correct)
- Project-structure block: added `app/api/` (route handlers — MCP server + AI skill improvement) and `proxy.ts` (security headers / CSP)

**CONTRIBUTING.md**
- Project-structure block: renamed `middleware.ts` → `proxy.ts` (Next 16 convention) and added the `app/api/` entry

## Verification

Confirmed against the working tree:
- `src/proxy.ts` exists; `src/middleware.ts` does not
- `src/app/api/` contains `[transport]/route.ts` and `skill/improve/route.ts`
- `package.json` pins `next@16.2.9` and `react@19.2.7`

Closes #86