### PR TITLE
feat: live GitHub contributors on About and workspace footers

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowRight, Github } from "lucide-react";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { Contributors, FooterContributors } from "@/components/contributors";
 
 const SITE_URL = "https://marksight.laramateo.com";
 const GITHUB_URL = "https://github.com/Rinava/MarkSight";
@@ -248,23 +249,7 @@ export default function AboutPage() {
               MarkSight is better because of the people who report bugs, suggest
               features, and open pull requests. Thank you!
             </p>
-            <a
-              href={`${GITHUB_URL}/graphs/contributors`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-block rounded-[13px] border border-ms-border-2 bg-ms-surface p-4 transition-colors hover:border-ms-border-hover"
-            >
-              {/* Third-party dynamic image (contrib.rocks); next/image adds no value. */}
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src="https://contrib.rocks/image?repo=Rinava/MarkSight"
-                alt="Avatars of MarkSight contributors on GitHub"
-                width={300}
-                height={60}
-                loading="lazy"
-                className="max-w-full"
-              />
-            </a>
+            <Contributors />
             <p className="text-[15px] leading-[1.7] text-ms-ink-body">
               Want to join them? Look for issues labelled{" "}
               <ExternalLink
@@ -340,6 +325,9 @@ export default function AboutPage() {
         <Link href="/" className="transition-colors hover:text-ms-primary-ink">
           Editor
         </Link>
+        <FooterContributors
+          separator={<span aria-hidden="true">·</span>}
+        />
         <span aria-hidden="true">·</span>
         <span title={`© ${year} laramateo.com. All rights reserved.`}>
           © {year}

--- a/src/components/contributors.tsx
+++ b/src/components/contributors.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useContributors } from "@/hooks/use-contributors";
+import { CONTRIBUTORS_GRAPH_URL, sizedAvatar } from "@/lib/contributors";
+
+/* External per-visitor avatars; plain <img> avoids next/image remote-pattern config. */
+
+export function Contributors() {
+  const { contributors, loading, error } = useContributors();
+
+  if (loading) {
+    return (
+      <div className="flex flex-wrap gap-2" aria-hidden="true">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-11 w-11 animate-pulse rounded-full bg-ms-hover"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (error || contributors.length === 0) {
+    return (
+      <a
+        href={CONTRIBUTORS_GRAPH_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block rounded-[13px] border border-ms-border-2 bg-ms-surface p-4 transition-colors hover:border-ms-border-hover"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src="https://contrib.rocks/image?repo=Rinava/MarkSight"
+          alt="Avatars of MarkSight contributors on GitHub"
+          width={300}
+          height={60}
+          loading="lazy"
+          className="max-w-full"
+        />
+      </a>
+    );
+  }
+
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {contributors.map((c) => (
+        <li key={c.login}>
+          <a
+            href={c.profileUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`@${c.login} — ${c.contributions} commit${
+              c.contributions === 1 ? "" : "s"
+            }`}
+            className="block rounded-full ring-1 ring-ms-border transition-transform hover:-translate-y-0.5 hover:ring-ms-primary-ink"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={sizedAvatar(c.avatarUrl, 88)}
+              alt={`${c.login}, MarkSight contributor`}
+              width={44}
+              height={44}
+              loading="lazy"
+              className="h-11 w-11 rounded-full"
+            />
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function FooterContributors({
+  max = 5,
+  separator,
+}: {
+  max?: number;
+  /** Rendered only when the cluster has content, so a parent's divider never orphans. */
+  separator?: React.ReactNode;
+}) {
+  const { contributors, loading, error } = useContributors();
+
+  if (loading || error || contributors.length === 0) return null;
+
+  const shown = contributors.slice(0, max);
+  const extra = contributors.length - shown.length;
+
+  return (
+    <>
+      {separator}
+      <a
+        href={CONTRIBUTORS_GRAPH_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`${contributors.length} MarkSight contributors`}
+        title={`${contributors.length} contributors`}
+        className="flex items-center gap-1.5 transition-opacity hover:opacity-80"
+      >
+        <span className="flex -space-x-1.5">
+          {shown.map((c) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={c.login}
+              src={sizedAvatar(c.avatarUrl, 40)}
+              alt=""
+              width={20}
+              height={20}
+              loading="lazy"
+              className="h-5 w-5 rounded-full ring-1 ring-ms-surface"
+            />
+          ))}
+        </span>
+        {extra > 0 && <span>+{extra}</span>}
+      </a>
+    </>
+  );
+}

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { FooterContributors } from "@/components/contributors";
 import { MarkdownToolbar } from "@/components/markdown-toolbar";
 import { MarkdownEditorRef } from "@/components/markdown-editor";
 import { TooltipProvider, Tip } from "@/components/ui/base/tooltip";
@@ -36,7 +37,7 @@ import { useDebouncedValue } from "@/lib/use-debounced-value";
 import { documentMetrics } from "@/lib/markdown/metrics";
 import { buildSkillMd } from "@/lib/skill/build";
 
-const GITHUB_URL = "https://github.com/rinava/MarkSight";
+const GITHUB_URL = "https://github.com/Rinava/MarkSight";
 const PORTFOLIO_URL = "https://laramateo.com";
 
 const STARTER = `# Welcome to MarkSight
@@ -478,6 +479,7 @@ export function Workspace() {
             >
               GitHub
             </a>
+            <FooterContributors />
             <span title={`© ${currentYear} laramateo.com. All rights reserved.`}>
               © {currentYear}
             </span>

--- a/src/hooks/use-contributors.ts
+++ b/src/hooks/use-contributors.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchContributors, type Contributor } from "@/lib/contributors";
+
+// One shared fetch per session (About section + both footers). A cached promise,
+// not an AbortSignal, so one subscriber unmounting can't cancel it for the rest.
+let cache: Promise<Contributor[]> | null = null;
+
+function load(): Promise<Contributor[]> {
+  if (!cache) cache = fetchContributors();
+  return cache;
+}
+
+export interface UseContributors {
+  contributors: Contributor[];
+  loading: boolean;
+  error: boolean;
+}
+
+export function useContributors(): UseContributors {
+  const [state, setState] = useState<UseContributors>({
+    contributors: [],
+    loading: true,
+    error: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+    load()
+      .then((contributors) => {
+        if (active) setState({ contributors, loading: false, error: false });
+      })
+      .catch(() => {
+        cache = null; // let the next mount retry (e.g. after a rate-limit window)
+        if (active) setState({ contributors: [], loading: false, error: true });
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -1,0 +1,46 @@
+/**
+ * Unauthenticated GitHub API (60 req/hour per visitor IP); avatars load from
+ * avatars.githubusercontent.com, covered by the `img-src https:` CSP.
+ */
+
+export const CONTRIBUTORS_REPO = "Rinava/MarkSight";
+export const CONTRIBUTORS_GRAPH_URL = `https://github.com/${CONTRIBUTORS_REPO}/graphs/contributors`;
+
+const ENDPOINT = `https://api.github.com/repos/${CONTRIBUTORS_REPO}/contributors?per_page=100`;
+
+export interface Contributor {
+  login: string;
+  avatarUrl: string;
+  profileUrl: string;
+  contributions: number;
+}
+
+interface GitHubContributor {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  contributions: number;
+  type: string;
+}
+
+export function sizedAvatar(url: string, size: number): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}s=${size}`;
+}
+
+export async function fetchContributors(): Promise<Contributor[]> {
+  const res = await fetch(ENDPOINT, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) throw new Error(`GitHub API responded ${res.status}`);
+
+  const data: GitHubContributor[] = await res.json();
+  return data
+    .filter((c) => c.type !== "Bot")
+    .map((c) => ({
+      login: c.login,
+      avatarUrl: c.avatar_url,
+      profileUrl: c.html_url,
+      contributions: c.contributions,
+    }));
+}


### PR DESCRIPTION
## Summary

Replaces the static `contrib.rocks` banner on the About page with **live contributor avatars fetched from the GitHub API**, and adds a compact overlapping avatar cluster to both the About and workspace footers. All three consumers share a single per-session cached fetch, so the page makes at most one request.

## Changes

- **`src/lib/contributors.ts`** — Unauthenticated GitHub contributors fetch (`/repos/Rinava/MarkSight/contributors`), bot filtering, and an avatar-sizing helper. Uses `avatars.githubusercontent.com`, already covered by the `img-src https:` CSP.
- **`src/hooks/use-contributors.ts`** — `useContributors` hook backed by a module-level cached promise (shared across the About grid + both footers). A failed fetch clears the cache so the next mount can retry after a GitHub rate-limit window (60 req/hr per visitor IP).
- **`src/components/contributors.tsx`**
  - `Contributors` — avatar grid with a loading skeleton and a graceful fallback to the old `contrib.rocks` image on error/empty.
  - `FooterContributors` — compact overlapping avatar cluster with a `+N` overflow indicator; renders nothing (including its separator) while loading or on error so it never orphans a divider.
- **`src/app/about/page.tsx`** — Swap the static image for `<Contributors />`; add `<FooterContributors />` to the footer.
- **`src/components/workspace/workspace.tsx`** — Add `<FooterContributors />` to the footer; fix `GITHUB_URL` casing (`rinava` → `Rinava`).

## Verification

- `tsc --noEmit` — clean
- `eslint` — no new issues (one pre-existing warning in `outline-rail.tsx`, untouched)
- `vitest` — 85/85 passing