### PR TITLE
fix: align markdown metrics counts

### DIFF
--- a/src/lib/markdown/__tests__/markdown.test.ts
+++ b/src/lib/markdown/__tests__/markdown.test.ts
@@ -49,11 +49,14 @@ describe("documentMetrics", () => {
     const m = documentMetrics(md);
     expect(m.lineCount).toBe(3);
     expect(m.headingCount).toBe(1);
-    // Historical behavior: the link regex also matches an image's bracket
-    // part, so an image counts toward linkCount too.
-    expect(m.linkCount).toBe(2);
+    expect(m.linkCount).toBe(1);
     expect(m.imageCount).toBe(1);
     expect(m.characterCount).toBe(md.length);
+  });
+
+  it("counts setext headings like buildOutline", () => {
+    const md = "Title\n=====\n\ntext\n\nSection\n-------";
+    expect(documentMetrics(md).headingCount).toBe(2);
   });
 
   it("ignores # lines inside ``` and ~~~ fences", () => {

--- a/src/lib/markdown/metrics.ts
+++ b/src/lib/markdown/metrics.ts
@@ -12,23 +12,41 @@ export interface DocumentMetrics {
   imageCount: number;
 }
 
+const LINK_RE = /(?<!!)\[([^\]]+)\]\([^)]+\)/g;
+const IMAGE_RE = /!\[([^\]]*)\]\([^)]+\)/g;
+const ATX_HEADING_RE = /^#{1,6}\s/;
+const FENCE_RE = /^\s*(```|~~~)/;
+const SETEXT_RE = /^ {0,3}(=+|-+)[ \t]*$/;
+
 export function documentMetrics(content: string): DocumentMetrics {
   const lines = content.split('\n');
   const words = content.split(/\s+/).filter(word => word.length > 0);
   const characters = content.length;
-  const links = (content.match(/\[([^\]]+)\]\([^)]+\)/g) || []).length;
-  const images = (content.match(/!\[([^\]]*)\]\([^)]+\)/g) || []).length;
+  const links = (content.match(LINK_RE) || []).length;
+  const images = (content.match(IMAGE_RE) || []).length;
 
-  // Fence-aware ATX heading count (1–6 hashes), consistent with buildOutline.
   let insideFence = false;
   let headings = 0;
-  for (const line of lines) {
-    if (/^\s*(```|~~~)/.test(line)) {
+  lines.forEach((line, index) => {
+    if (FENCE_RE.test(line)) {
       insideFence = !insideFence;
-      continue;
+      return;
     }
-    if (!insideFence && /^#{1,6}\s/.test(line)) headings++;
-  }
+    if (insideFence) return;
+
+    if (ATX_HEADING_RE.test(line)) {
+      headings++;
+      return;
+    }
+
+    const setext = line.match(SETEXT_RE);
+    if (setext) {
+      const prev = lines[index - 1];
+      if (prev && prev.trim() && !ATX_HEADING_RE.test(prev) && !FENCE_RE.test(prev)) {
+        headings++;
+      }
+    }
+  });
 
   return {
     wordCount: words.length,


### PR DESCRIPTION
## Description

Fixes markdown document metrics so they align with the outline parser and avoid double-counting images as links.

Changes:
- Count regular markdown links without matching image syntax (`![alt](url)`).
- Count setext headings (`Title` + `=====` / `Section` + `-----`) the same way `buildOutline` does.
- Update markdown metrics tests for link/image separation and setext heading coverage.

## Related issue

Closes #81.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] 🧹 Refactor / chore (no user-facing change)

## Screenshots / recording

N/A — pure markdown metrics logic and tests only.

## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [ ] I tested my change in the browser
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I updated docs where relevant

## Validation

- `npm test -- src/lib/markdown/__tests__/markdown.test.ts` — 13 tests passed
- `npm run lint` — passed with 0 errors; existing warning remains in `src/components/workspace/outline-rail.tsx`, outside this change
- `npm run build` — succeeded
