### PR TITLE
fix(workspace): add try/catch error handling to export actions

### DIFF
--- a/src/components/workspace/export-menu.tsx
+++ b/src/components/workspace/export-menu.tsx
@@ -110,39 +110,51 @@ export function ExportMenu({
   const { trackExportAction, trackSkillAction } = useAnalytics();
 
   async function exportHTML() {
-    trackExportAction("html", content);
-    downloadBlob(
-      await renderExportHtml(content, filename),
-      `${filename}.html`,
-      "text/html",
-    );
-    toast.success("HTML exported");
+    try {
+      trackExportAction("html", content);
+      downloadBlob(
+        await renderExportHtml(content, filename),
+        `${filename}.html`,
+        "text/html",
+      );
+      toast.success("HTML exported");
+    } catch {
+      toast.error("Failed to export HTML");
+    }
   }
 
   async function exportPDF() {
-    trackExportAction("pdf", content);
-    const html = await renderExportHtml(content, filename);
-    const printWindow = window.open("", "_blank");
-    if (!printWindow) {
-      toast.error("Allow pop-ups to export as PDF");
-      return;
+    try {
+      trackExportAction("pdf", content);
+      const html = await renderExportHtml(content, filename);
+      const printWindow = window.open("", "_blank");
+      if (!printWindow) {
+        toast.error("Allow pop-ups to export as PDF");
+        return;
+      }
+      printWindow.document.write(html);
+      printWindow.document.close();
+      setTimeout(() => {
+        printWindow.print();
+      }, 400);
+    } catch {
+      toast.error("Failed to export PDF");
     }
-    printWindow.document.write(html);
-    printWindow.document.close();
-    setTimeout(() => {
-      printWindow.print();
-    }, 400);
   }
 
   async function previewHTML() {
-    const html = await renderExportHtml(content, filename);
-    const newWindow = window.open("", "_blank");
-    if (!newWindow) {
-      toast.error("Allow pop-ups to preview HTML");
-      return;
+    try {
+      const html = await renderExportHtml(content, filename);
+      const newWindow = window.open("", "_blank");
+      if (!newWindow) {
+        toast.error("Allow pop-ups to preview HTML");
+        return;
+      }
+      newWindow.document.write(html);
+      newWindow.document.close();
+    } catch {
+      toast.error("Failed to preview HTML");
     }
-    newWindow.document.write(html);
-    newWindow.document.close();
   }
 
   function downloadMarkdown() {


### PR DESCRIPTION
## Problem

In `export-menu.tsx`, the `exportHTML` / `exportPDF` / `previewHTML` async handlers call the renderer without a `try/catch`. If `renderExportHtml` throws (e.g., remark/rendering fails), it's an unhandled promise rejection with no user feedback — unlike `downloadSkillZip` / `copySkillMd` in the same file, which already catch and toast.

## Fix

Wrapped the async bodies of `exportHTML`, `exportPDF`, and `previewHTML` in `try/catch` blocks. On failure, each shows a `sonner` error toast matching the existing error handling pattern in the file.

- `exportHTML` → `toast.error("Failed to export HTML")`
- `exportPDF` → `toast.error("Failed to export PDF")`
- `previewHTML` → `toast.error("Failed to preview HTML")`

No changes to the happy path — success toasts remain unchanged.

## Test Plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] ESLint passes (`eslint src/components/workspace/export-menu.tsx`)
- [x] All 85 existing tests pass (`vitest run`)
- [ ] Manual: trigger a rendering failure and verify error toast appears

Closes #82
