### PR TITLE
fix: add App Router error boundary

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { Button } from "@/components/ui/button";
+
+
+type ErrorBoundaryProps = {
+  error: Error & { digest?: string },
+  reset: () => void
+}
+
+export default function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-center antialiased">
+      <div className="max-w-md space-y-6 rounded-lg border border-border bg-card p-8 shadow-sm">
+        {/* Visual Alert Icon */}
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="h-6 w-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
+            />
+          </svg>
+        </div>
+
+        {/* Text Stack - Surfacing only a generic message and the safe identifier */}
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold tracking-tight text-foreground">
+            Something went wrong
+          </h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            We couldn&apos;t load this page because an unexpected error occurred.
+            Please try again below
+          </p>
+          {error.digest && (
+            <p className="font-mono text-xs text-muted-foreground/60 select-all pt-1">
+              Error ID: {error.digest}
+            </p>
+          )}
+        </div>
+
+        {/* Action Callbacks */}
+        <div className="pt-2">
+          <Button
+            onClick={() => reset()}
+            variant="default"
+            className="w-full font-medium transition-colors"
+          >
+            Try again
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds an App Router `error.tsx` error boundary to provide a themed fallback UI when a route segment fails to render.

This replaces the default unstyled Next.js error page with a user-friendly error screen that:

- Displays a generic error message
- Optionally shows the safe `error.digest` identifier
- Provides a **Try Again** button that calls `reset()`
- Reuses the existing design system (`Button`) and theme tokens for consistent light/dark mode styling

## Related issue

Closes #45

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] 🧹 Refactor / chore (no user-facing change)

## Screenshots / recording

<img width="1914" height="1069" alt="Error boundary" src="https://github.com/user-attachments/assets/3f91e313-86ca-4773-936c-65c51f1154a4" />

<img width="2543" height="1391" alt="image" src="https://github.com/user-attachments/assets/165c3e4a-b76d-44b7-855e-9cfaf6ac4d50" />


## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run lint` passes with no new errors*
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] I tested my change in the browser
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I updated docs where relevant

\* `npm run lint` reports an existing warning in `src/components/workspace/outline-rail.tsx` unrelated to this change. No new lint errors or warnings were introduced by this PR.