### PR TITLE
fix: open external preview links in a new tab safely

### DIFF
--- a/src/components/markdown-preview.tsx
+++ b/src/components/markdown-preview.tsx
@@ -47,21 +47,12 @@ export const MarkdownPreview = memo(function MarkdownPreview({
           a({ href, children, ...props }) {
             const isExternal = /^https?:\/\//.test(href ?? "");
 
-            if (isExternal) {
-              return (
-                <a
-                  href={href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  {...props}
-                >
-                  {children}
-                </a>
-              );
-            }
+            const external = isExternal
+              ? { target: "_blank", rel: "noopener noreferrer" }
+              : {};
 
             return (
-              <a href={href} {...props}>
+              <a href={href} {...external} {...props}>
                 {children}
               </a>
             );

--- a/src/components/markdown-preview.tsx
+++ b/src/components/markdown-preview.tsx
@@ -44,11 +44,35 @@ export const MarkdownPreview = memo(function MarkdownPreview({
             if (isMermaidPre(node)) return <>{children}</>;
             return <pre {...props}>{children}</pre>;
           },
+          a({ href, children, ...props }) {
+            const isExternal = /^https?:\/\//.test(href ?? "");
+
+            if (isExternal) {
+              return (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  {...props}
+                >
+                  {children}
+                </a>
+              );
+            }
+
+            return (
+              <a href={href} {...props}>
+                {children}
+              </a>
+            );
+          },
           code({ className: codeClassName, children }) {
             const match = /language-(\w+)/.exec(codeClassName ?? "");
 
             if (match?.[1] === "mermaid") {
-              return <MermaidDiagram code={String(children).replace(/\n$/, "")} />;
+              return (
+                <MermaidDiagram code={String(children).replace(/\n$/, "")} />
+              );
             }
 
             // ReactMarkdown: inline code has no className; code blocks carry a


### PR DESCRIPTION
## Description

Added a custom link renderer to the Markdown preview so that external HTTP/HTTPS links open in a new tab with `target="_blank"` and `rel="noopener noreferrer"` for improved security. Internal anchor and relative links continue to open in the same tab without changing their existing behavior.

## Related issue

Closes #23
