### PR TITLE
fix: hide decorative logo icon from accessibility tree

### DIFF
--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -17,6 +17,7 @@ export function LogoMark({ className = "" }: { className?: string }) {
       strokeLinecap="round"
       strokeLinejoin="round"
       aria-hidden="true"
+      focusable="false"
       className={`text-ms-primary-ink ${className}`}
     >
       <path d="M8 2v3" />


### PR DESCRIPTION
## Description

Added `focusable="false"` to the decorative logo SVG to complement the existing `aria-hidden="true"` attribute. This ensures the decorative icon remains hidden from the accessibility tree while the visible "MarkSight" text continues to provide the accessible name, with no visual changes.

## Related issue

Closes #39
