### PR TITLE
feat: add copy button to code blocks in markdown preview

### DIFF
--- a/src/components/markdown-preview.tsx
+++ b/src/components/markdown-preview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo,useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
@@ -27,27 +27,38 @@ function CodeBlock({
   isDark: boolean;
 }) {
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   async function handleCopy() {
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
 
-      setTimeout(() => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+
+      timerRef.current = setTimeout(() => {
         setCopied(false);
       }, 2000);
     } catch (err) {
       console.error("Failed to copy:", err);
     }
   }
-
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
   return (
     <div className="relative">
       <Button
         size="sm"
         variant="secondary"
         onClick={handleCopy}
-        aria-label="Copy code"
+        aria-label={copied ? "Copied" : "Copy code"}
         className="absolute right-2 top-2 z-10"
       >
         {copied ? <Check size={16} /> : <Copy size={16} />}
@@ -88,7 +99,6 @@ export interface MarkdownPreviewProps {
  * `value` only changes ~10×/s — so react-markdown re-parses on prop changes,
  * not on every keystroke. Theme changes still re-render via context.
  */
-
 export const MarkdownPreview = memo(function MarkdownPreview({
   value,
   className = "ms-prose",
@@ -111,7 +121,9 @@ export const MarkdownPreview = memo(function MarkdownPreview({
             const match = /language-(\w+)/.exec(codeClassName ?? "");
 
             if (match?.[1] === "mermaid") {
-              return <MermaidDiagram code={String(children).replace(/\n$/, "")} />;
+              return (
+                <MermaidDiagram code={String(children).replace(/\n$/, "")} />
+              );
             }
 
             // ReactMarkdown: inline code has no className; code blocks carry a

--- a/src/components/markdown-preview.tsx
+++ b/src/components/markdown-preview.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { memo } from "react";
+import { memo,useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import { useTheme } from "next-themes";
 import { SyntaxHighlighter, oneDark, oneLight } from "@/lib/syntax-highlighter";
 import { MermaidDiagram } from "@/components/mermaid-diagram";
+import { Button } from "@/components/ui/button";
+import { Copy, Check } from "lucide-react";
 
 function isMermaidPre(node: unknown): boolean {
   const child = (node as { children?: Array<Record<string, unknown>> })
@@ -15,7 +17,67 @@ function isMermaidPre(node: unknown): boolean {
   const className = (child.properties as { className?: unknown })?.className;
   return Array.isArray(className) && className.includes("language-mermaid");
 }
+function CodeBlock({
+  code,
+  language,
+  isDark,
+}: {
+  code: string;
+  language: string;
+  isDark: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
 
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={handleCopy}
+        aria-label="Copy code"
+        className="absolute right-2 top-2 z-10"
+      >
+        {copied ? <Check size={16} /> : <Copy size={16} />}
+      </Button>
+
+      <SyntaxHighlighter
+        PreTag="div"
+        language={language}
+        style={isDark ? oneDark : oneLight}
+        customStyle={{
+          background: "var(--ms-tint)",
+          border: "1px solid var(--ms-border-2)",
+          borderRadius: "9px",
+          padding: "0.9em 1.05em",
+          margin: "1em 0",
+          fontSize: "0.85em",
+          transition: "background-color 0.3s ease",
+        }}
+        codeTagProps={{
+          style: {
+            fontFamily:
+              "var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+          },
+        }}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  );
+}
 export interface MarkdownPreviewProps {
   value: string;
   className?: string;
@@ -26,6 +88,7 @@ export interface MarkdownPreviewProps {
  * `value` only changes ~10×/s — so react-markdown re-parses on prop changes,
  * not on every keystroke. Theme changes still re-render via context.
  */
+
 export const MarkdownPreview = memo(function MarkdownPreview({
   value,
   className = "ms-prose",
@@ -60,30 +123,13 @@ export const MarkdownPreview = memo(function MarkdownPreview({
               // Styled by `.ms-prose :not(pre) > code` in globals.css.
               return <code>{children}</code>;
             }
-
+            const code = String(children).replace(/\n$/, "");
             return (
-              <SyntaxHighlighter
-                PreTag="div"
+              <CodeBlock
+                code={code}
                 language={match ? match[1] : "text"}
-                style={isDark ? oneDark : oneLight}
-                customStyle={{
-                  background: "var(--ms-tint)",
-                  border: "1px solid var(--ms-border-2)",
-                  borderRadius: "9px",
-                  padding: "0.9em 1.05em",
-                  margin: "1em 0",
-                  fontSize: "0.85em",
-                  transition: "background-color 0.3s ease",
-                }}
-                codeTagProps={{
-                  style: {
-                    fontFamily:
-                      "var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
-                  },
-                }}
-              >
-                {String(children).replace(/\n$/, "")}
-              </SyntaxHighlighter>
+                isDark={isDark}
+              />
             );
           },
         }}


### PR DESCRIPTION
## Description

Adds a copy button to rendered code blocks in the markdown preview.

- Adds a copy button to each code block.
- Copies the exact code using the Clipboard API.
- Shows a temporary check icon after a successful copy.
- Leaves inline code rendering unchanged.

## Related issue

Closes #22

## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run build` succeeds
- [x] I tested my change in the browser