### PR TITLE
ci: unblock failing dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    ignore:
+      # mcp-handler pins peer @modelcontextprotocol/sdk to an exact version, so
+      # bumping the SDK alone breaks `npm ci`. Drop once mcp-handler unpins.
+      - dependency-name: "@modelcontextprotocol/sdk"
     groups:
       # Batch low-risk minor/patch bumps into a single PR to cut review noise.
       minor-and-patch:

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight, Github } from "lucide-react";
+import { ArrowRight } from "lucide-react";
+import { GithubIcon } from "@/components/icons";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Contributors, FooterContributors } from "@/components/contributors";
@@ -159,7 +160,7 @@ export default function AboutPage() {
           aria-label="View on GitHub"
           className={ICON_BTN}
         >
-          <Github className="h-[17px] w-[17px]" aria-hidden="true" />
+          <GithubIcon className="h-[17px] w-[17px]" aria-hidden="true" />
         </a>
       </header>
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,23 @@
+import type { SVGProps } from "react";
+
+// Drop-in for lucide's Github icon — lucide v1 removed brand icons.
+// Path copied from lucide-react 0.544.0 (ISC) so the mark renders identically.
+export function GithubIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  );
+}

--- a/src/components/workspace/open-skill-menu.tsx
+++ b/src/components/workspace/open-skill-menu.tsx
@@ -8,8 +8,8 @@ import {
   FilePlus2,
   FileUp,
   FolderOpen,
-  Github,
 } from "lucide-react";
+import { GithubIcon } from "@/components/icons";
 import { toast } from "sonner";
 import { useContent } from "@/contexts/content-context";
 import { useSkillMeta } from "@/contexts/skill-meta-context";
@@ -296,7 +296,7 @@ export function OpenSkillMenu({ onEnterSkill }: { onEnterSkill: () => void }) {
                       className={ITEM_CLASS}
                     >
                       <span className="flex text-ms-primary-ink">
-                        <Github className="h-[18px] w-[18px]" aria-hidden="true" />
+                        <GithubIcon className="h-[18px] w-[18px]" aria-hidden="true" />
                       </span>
                       <span className="min-w-0 flex-1 truncate">
                         <span className="block truncate text-[13px] font-medium">

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import {
   BookOpen,
   CircleCheck,
-  Github,
   RotateCcw,
   Sparkles,
   TriangleAlert,
@@ -13,6 +12,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
+import { GithubIcon } from "@/components/icons";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { FooterContributors } from "@/components/contributors";
@@ -300,7 +300,7 @@ export function Workspace() {
               aria-label="View on GitHub"
               className={ICON_BTN}
             >
-              <Github className="h-[17px] w-[17px]" aria-hidden="true" />
+              <GithubIcon className="h-[17px] w-[17px]" aria-hidden="true" />
             </a>
           </Tip>
         </header>


### PR DESCRIPTION
## Description

Fixes the two red dependabot PRs at their root cause:

- **#96 (lucide-react 1.x)** fails because lucide v1 removed brand icons, including `Github`. Replaced the three usages with a local `GithubIcon` (path copied verbatim from lucide-react 0.544.0, ISC) so the mark renders identically and the bump can land.
- **#93 (minor-and-patch group)** fails `npm ci` because the group bumps `@modelcontextprotocol/sdk` to 1.29.0 while `mcp-handler@1.1.0` (latest) pins its peer to exactly 1.26.0. Added a dependabot `ignore` for the SDK until mcp-handler unpins.

After merging, comment `@dependabot recreate` on #93 and `@dependabot rebase` on #96 to regenerate them against this change.

## Type of change

- [x] 🧹 Refactor / chore (no user-facing change)

## Checklist

- [x] `npm run lint` passes (only the pre-existing outline-rail warning)
- [x] `npm test` passes (86/86)
- [x] `npm run build` succeeds