### PR TITLE
refactor: reuse escapeRegExp in markdown toolbar

### DIFF
--- a/src/components/markdown-toolbar.tsx
+++ b/src/components/markdown-toolbar.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { escapeRegExp } from "@/lib/utils";
 import { useEffect, useCallback, useMemo } from "react";
 import { Tip } from "@/components/ui/base/tooltip";
 import { useAnalytics } from "@/hooks/use-analytics";
@@ -199,13 +199,13 @@ export function MarkdownToolbar({ onInsert, getCurrentContext, selectionVersion 
       
       // Check if the selected text exactly matches a markdown pattern
       const selectedPattern = markdownPatterns.find(pattern => {
-        const match = selectedText.match(new RegExp(`^${pattern.before.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(.+)${pattern.after.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`));
+        const match = selectedText.match(new RegExp(`^${escapeRegExp(pattern.before)}(.+)${escapeRegExp(pattern.after)}$`));
         return match && pattern.type === elementType;
       });
       
       if (selectedPattern) {
         // Remove formatting from selected text
-        const innerMatch = selectedText.match(new RegExp(`^${selectedPattern.before.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(.+)${selectedPattern.after.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`));
+        const innerMatch = selectedText.match(new RegExp(`^${escapeRegExp(selectedPattern.before)}(.+)${escapeRegExp(selectedPattern.after)}$`));
         if (innerMatch) {
           const innerText = innerMatch[1];
           onInsert(innerText, innerText.length, selection.from, selection.to);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,33 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function downloadBlob(
+  data: BlobPart,
+  name: string,
+  mime: string,
+) {
+  const url = URL.createObjectURL(new Blob([data], { type: mime }));
+
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = name;
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+}
+
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,32 +4,6 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
-export function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-export function downloadBlob(
-  data: BlobPart,
-  name: string,
-  mime: string,
-) {
-  const url = URL.createObjectURL(new Blob([data], { type: mime }));
-
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = name;
-
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-
-  URL.revokeObjectURL(url);
-}
 
 export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
## Description

Reuses the shared `escapeRegExp` utility in the markdown toolbar instead of duplicating the regular expression escaping logic inline. This reduces duplicated code while preserving the existing behavior.

**Note:** `npm test` currently fails due to a missing `fflate` dependency in the local environment, which is unrelated to this change. `npm run lint` completes with one pre-existing warning in `outline-rail.tsx` unrelated to this PR.

## Related issue

Closes #72

## Type of change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that changes existing behavior)
* [ ] 📖 Documentation
* [x] 🧹 Refactor / chore (no user-facing change)

## Screenshots / recording

Not applicable (no UI changes).

## Checklist

* [x] My branch is up to date with `main`
* [x] `npm run lint` passes (with one unrelated pre-existing warning)
* [ ] `npm test` passes
* [x] `npm run build` succeeds
* [x] I tested my change in the browser
* [x] My commits follow Conventional Commits
* [ ] I updated docs where relevant
