### PR TITLE
docs: add changelog and rewrite README/CONTRIBUTING in a human voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,117 @@
+# Changelog
+
+All notable changes to MarkSight are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Everything before this file existed was reconstructed from git history.
+
+## [Unreleased]
+
+### Added
+
+- Error boundary: a runtime error now shows a recovery page instead of a
+  blank screen
+- Placeholder text in the empty markdown editor
+
+### Fixed
+
+- Decorative logo icon hidden from the accessibility tree
+- GitHub brand icon replaced with a local SVG (lucide dropped brand icons)
+
+### Dependencies
+
+- `ai` 6 → 7, `zod` 3 → 4, `typescript` 5.9 → 6.0, `lucide-react` 0.544 → 1.23,
+  plus grouped minor/patch updates
+- Dependabot no longer auto-bumps `@modelcontextprotocol/sdk` (pinned for MCP
+  protocol stability)
+
+## [1.0.0] - 2026-07-06
+
+The 1.0. What started as a markdown editor became a tool that turns any
+document into an installable Claude Agent Skill, plus an MCP server that
+Claude can call directly.
+
+### Added
+
+- Skill Creator: export any document as an [Agent Skill](https://code.claude.com/docs/en/skills)
+  (⌘⇧K). One click downloads a validated `.skill` bundle, and an optional
+  sidebar panel lets you edit the name and trigger description inline
+- Skill import: open a `.skill`/`.zip` bundle or `SKILL.md`, or import
+  straight from GitHub-hosted marketplaces (e.g. `anthropics/skills`), edit,
+  and re-export with bundled files preserved
+- Knowledge mode, quality hints, and a starter template for skills
+- MCP server at `/api/mcp` (streamable HTTP) exposing `create_skill`,
+  `validate_skill`, `markdown_to_html`, `document_outline`, and
+  `document_metrics`, plus a project-scoped `.mcp.json` and an MCP registry
+  `server.json`
+- AI refinement of skill name and trigger description via Vercel AI
+  Gateway (gated behind backend credentials), with a free-tier path using a
+  direct Google Gemini API key
+- Mermaid diagrams: fenced `mermaid` blocks render as live SVG in the
+  preview and in exports, themeable per diagram
+- Re-architected PDF/HTML export with unified rendering and reliable print
+- Download button for the raw Markdown source ([#34](https://github.com/Rinava/MarkSight/pull/34))
+- Word and character count in the editor footer
+- Markdown guide overlay reachable from the toolbar
+- About page with FAQ schema, community links, and credits
+- Live GitHub contributors shown on the About page and workspace footer
+- Custom 404 page
+- `llms.txt` for AI-assistant discoverability
+
+### Changed
+
+- Upgraded to Next.js 16
+- Reset/Clear moved into the toolbar; refreshed button styles
+- Skill draft logic factored into a tested pure module
+- README restructured around the Skill/MCP workflow
+
+### Fixed
+
+- Keyboard shortcuts scoped to the focused editor
+- Outline sidebar staying attached at wide viewports
+- PDF print triggered from the opener window (the previous injected script was
+  blocked by CSP)
+- Markdown metrics counts aligned between footer and MCP tools
+- Export actions wrapped in error handling with user-facing feedback
+- Load-time layout shift eliminated and client bundle size reduced
+- Correctness, accessibility, and SEO/social metadata fixes across the app
+- Hydration and react-hooks issues from the Next.js 16 upgrade
+
+### Security
+
+- Content-Security-Policy and security headers added (`src/proxy.ts`)
+- Next.js bumped past a critical CVE; `postcss` floored at ≥ 8.5.10
+  (Dependabot alert #33)
+- API input validation and rate limiting hardened
+
+### Infrastructure
+
+- Contributor infrastructure: CI workflow, issue/PR templates, CONTRIBUTING,
+  SECURITY, and Code of Conduct ([#10](https://github.com/Rinava/MarkSight/pull/10))
+- Unit tests (Vitest) run in CI before the build
+
+## [0.1.0] - 2025-10-02
+
+The original release: the editor built to end the write-preview-write-preview
+tab dance of editing Markdown on GitHub. Everything runs in the browser.
+
+### Added
+
+- CodeMirror editor with instantly rendered live preview (GitHub-flavored
+  markdown via `remark-gfm`)
+- Smart formatting toolbar and keyboard shortcuts (bold, italic,
+  strikethrough, links, code, headings, lists)
+- Document outline sidebar with clickable heading navigation
+- Reset/Clear with undo via toast notifications
+- Light/dark theme, system-aware and persisted
+- Automatic document persistence to `localStorage`, so nothing leaves the browser
+- Syntax highlighting for fenced code blocks
+- Open Graph/Twitter metadata, web manifest, robots.txt, structured data, and
+  favicon
+- Vercel Analytics and Google Analytics (via `@next/third-parties`)
+- Responsive layout and mobile improvements
+
+[Unreleased]: https://github.com/Rinava/MarkSight/compare/29b9c56...HEAD
+[1.0.0]: https://github.com/Rinava/MarkSight/compare/1eeefbb...29b9c56
+[0.1.0]: https://github.com/Rinava/MarkSight/commits/1eeefbb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing to MarkSight
 
 Thanks for taking the time to contribute! 🎉 MarkSight is an open source
-markdown editor, and contributions of every size are welcome — from fixing a
+markdown editor, and contributions of every size are welcome, from fixing a
 typo to building a new feature.
 
 This guide explains how to get set up and how to land a change. If anything
-here is unclear or out of date, that's a bug too — open an issue or PR.
+here is unclear or out of date, that's a bug too: open an issue or PR.
 
 ## Table of contents
 
@@ -50,7 +50,7 @@ npm install
 npm run dev
 ```
 
-That's it — edit a file under `src/` and the page hot-reloads.
+That's it. Edit a file under `src/` and the page hot-reloads.
 
 ### Available scripts
 
@@ -110,12 +110,12 @@ src/
   [shadcn/ui](https://ui.shadcn.com/) primitives in `src/components/ui`. Add new
   primitives with the shadcn CLI rather than copying files by hand.
 - **Formatting:** an [`.editorconfig`](./.editorconfig) defines the basics
-  (2-space indent, LF line endings). Keep the diff small — match the style of
+  (2-space indent, LF line endings). Keep the diff small: match the style of
   the surrounding code and let ESLint guide you.
 - **Linting:** `npm run lint` must pass with no errors. Fix warnings you
   introduce.
-- **Accessibility:** keep it keyboard-navigable and screen-reader friendly —
-  label interactive controls, preserve focus order, and don't remove focus
+- **Accessibility:** keep it keyboard-navigable and screen-reader friendly.
+  Label interactive controls, preserve focus order, and don't remove focus
   outlines.
 - **Dependencies:** avoid adding a dependency for something small. If a new
   package is genuinely needed, mention why in the PR.
@@ -138,15 +138,17 @@ Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
 ## Opening a pull request
 
 1. Target the `main` branch.
-2. Fill in the PR template — describe **what** changed and **why**, and link any
+2. Fill in the PR template: describe **what** changed and **why**, and link any
    related issue (e.g. `Closes #12`).
 3. Add before/after screenshots or a short clip for any visible UI change.
-4. Confirm `npm run lint`, `npm test`, and `npm run build` pass locally.
-5. Keep the PR focused — one logical change per PR is much easier to review.
+4. If your change is user-facing, add a line to the **Unreleased** section of
+   [`CHANGELOG.md`](./CHANGELOG.md).
+5. Confirm `npm run lint`, `npm test`, and `npm run build` pass locally.
+6. Keep the PR focused. One logical change per PR is much easier to review.
 
 A maintainer aims to give every pull request a first response within a few days.
 They'll review your PR, may suggest changes, and will merge it once it's ready.
-Don't be discouraged by review feedback — it's how we keep the codebase healthy.
+Don't be discouraged by review feedback; it's how we keep the codebase healthy.
 
 ## Reporting bugs & requesting features
 
@@ -155,7 +157,7 @@ Use the issue templates so we get the details we need:
 - **Bugs:** include steps to reproduce, what you expected, what happened, and
   your browser/OS. A screenshot or console error helps a lot.
 - **Features:** describe the problem you're trying to solve, not just the
-  solution — it helps us find the best fit for the project.
+  solution. It helps us find the best fit for the project.
 
 Please search [existing issues](https://github.com/Rinava/MarkSight/issues)
 first to avoid duplicates.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # MarkSight
 
-**Turn any Markdown document into an installable [Claude Agent Skill](https://code.claude.com/docs/en/skills) — one click, in your browser.** MarkSight is a free, open source Markdown editor whose core doubles as a remote [MCP](https://modelcontextprotocol.io) server that Claude Code can call directly. Live preview, GFM, Mermaid diagrams, and Markdown/HTML/PDF export come with it.
+[![CI](https://github.com/Rinava/MarkSight/actions/workflows/ci.yml/badge.svg)](https://github.com/Rinava/MarkSight/actions/workflows/ci.yml)
+[![Contributors](https://img.shields.io/github/contributors/Rinava/MarkSight)](https://github.com/Rinava/MarkSight/graphs/contributors)
+[![GitHub stars](https://img.shields.io/github/stars/Rinava/MarkSight)](https://github.com/Rinava/MarkSight/stargazers)
+[![Last commit](https://img.shields.io/github/last-commit/Rinava/MarkSight)](https://github.com/Rinava/MarkSight/commits/main)
+[![License](https://img.shields.io/github/license/Rinava/MarkSight)](./LICENSE)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
+
+**Turn any Markdown document into an installable [Claude Agent Skill](https://code.claude.com/docs/en/skills). One click, in your browser.** MarkSight is a free, open source Markdown editor whose core doubles as a remote [MCP](https://modelcontextprotocol.io) server that Claude Code can call directly. Live preview, GFM, Mermaid diagrams, and Markdown/HTML/PDF export come with it.
 
 🔗 **Live (no signup):** [marksight.laramateo.com](https://marksight.laramateo.com)  ·  🧩 One-click `.skill` export  ·  🔌 Built-in MCP server  ·  🔒 100% client-side
 
@@ -11,9 +18,9 @@
 
 ## Quick start
 
-**Use it — nothing to install:**
+**Use it (nothing to install):**
 
-1. Open [marksight.laramateo.com](https://marksight.laramateo.com), write or paste Markdown, and press **⌘⇧K** — an installable `.skill` bundle downloads immediately.
+1. Open [marksight.laramateo.com](https://marksight.laramateo.com), write or paste Markdown, and press **⌘⇧K**. An installable `.skill` bundle downloads immediately.
 2. Or add MarkSight's MCP server to Claude Code and let Claude build and validate skills for you:
 
    ```bash
@@ -26,11 +33,25 @@ Want to run MarkSight locally or contribute? See [Getting started](#getting-star
 
 ## About
 
-MarkSight is a free, open source markdown editor that runs entirely in your
-browser — no account, no server-side storage. Documents are persisted to
-`localStorage` and exports are generated client-side, so your writing never
-leaves your device. It was created by [Lara Mateo](https://laramateo.com) and
-is developed in the open with the help of community contributors.
+Every README I've ever written started the same way: type some Markdown into
+GitHub's editor, click Preview, spot something broken, click back to Write,
+fix it, click Preview again. Write, preview, write, preview. Tiny friction,
+repeated a thousand times, stops being tiny. So I did the most programmer
+thing possible: I built my own editor.
+
+MarkSight is the editor I wanted to exist: the preview lives right next to
+your words. No tabs, no round trips, everything rendering live as you type.
+I built it with React, Next.js, TypeScript, and CodeMirror, and obsessed
+over making it feel snappy. It runs entirely in your browser, with no
+account and no server-side storage: your document sits in `localStorage`,
+exports are generated on your machine, and your writing never leaves your
+device.
+
+I could have kept it as a private little tool that solved a private little
+annoyance. Instead I made it open source, free for anyone to use, fork,
+break, and improve. That decision turned out to matter more than any feature
+I shipped. The longer version of that story is on my blog:
+[Why I built an open source Markdown editor](https://laramateo.com/blog/open-source-markdown-editor).
 
 ## Features
 
@@ -84,9 +105,9 @@ npm run lint     # run ESLint
 ### Exporting a document as an Agent Skill
 
 One click: hit the package icon in the preview toolbar (or ⌘⇧K) and a
-validated `<name>.skill` bundle downloads immediately — metadata is derived
-from your document (first H1 → name, first paragraph → description) and the
-toast shows the add-to-Claude steps.
+validated `<name>.skill` bundle downloads immediately. The metadata comes
+from your document (the first H1 becomes the name, the first paragraph the
+description) and the toast shows the add-to-Claude steps.
 
 Everything optional lives in the **Agent Skill** sidebar card: edit the name
 and trigger description inline (validated as you type), switch between
@@ -105,12 +126,12 @@ upload the `.skill` file under **Settings › Capabilities › Skills**.
 
 Optionally, an **Improve with AI** button refines the skill's name and trigger
 description (via Vercel AI Gateway). It appears only when the backend has
-gateway credentials — see [`.env.example`](./.env.example); without them the
+gateway credentials (see [`.env.example`](./.env.example)); without them the
 whole Skill Creator keeps working offline.
 
 You can also **import an existing skill** from the same dialog: open a
 `.skill`/`.zip` bundle or `SKILL.md` file, or paste a GitHub URL (a repo, a
-folder, or a `SKILL.md` link — e.g. the official
+folder, or a `SKILL.md` link, e.g. the official
 [anthropics/skills](https://github.com/anthropics/skills) collection). The
 skill's frontmatter is preserved (frontmatter always overrides auto-derived
 metadata), bundled files like `references/` are carried through untouched, and
@@ -126,9 +147,9 @@ call it directly:
 claude mcp add --transport http marksight https://marksight.laramateo.com/api/mcp
 ```
 
-Tools: `create_skill` (markdown → validated `.skill` bundle, base64),
-`validate_skill`, `markdown_to_html`, `document_outline`, `document_metrics` —
-all backed by the same `src/lib` code the editor uses. A project-scoped
+Tools: `create_skill` (markdown in, validated `.skill` bundle out as base64),
+`validate_skill`, `markdown_to_html`, `document_outline`, and
+`document_metrics`, all backed by the same `src/lib` code the editor uses. A project-scoped
 [`.mcp.json`](./.mcp.json) is included, so cloning this repo wires the
 connector automatically in Claude Code.
 
@@ -159,13 +180,14 @@ src/
 
 ## Contributing
 
-Contributions are welcome — whether it's a bug report, a feature idea, a docs
+Contributions are welcome, whether it's a bug report, a feature idea, a docs
 fix, or a pull request. See the [contributing guide](./CONTRIBUTING.md) for how
 to set up the project and submit changes, and please follow our
 [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 New here? Look for issues labelled
 [`good first issue`](https://github.com/Rinava/MarkSight/issues?q=is%3Aopen+label%3A%22good+first+issue%22).
+Release history lives in the [changelog](./CHANGELOG.md).
 
 ## Community
 
@@ -176,14 +198,25 @@ For bugs and feature requests, open an
 
 ## Contributors
 
-Thanks to everyone who has helped make MarkSight better:
+Here's the thing nobody tells you about open sourcing a project: at some
+point, the code stops being the point. The first time a stranger opened a
+pull request here, I just sat there smiling at my screen. Every avatar below
+is someone who read the code, understood it, and spent their free time
+making it better:
 
 <a href="https://github.com/Rinava/MarkSight/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=Rinava/MarkSight" alt="MarkSight contributors" />
 </a>
 
-Want to see yourself here? Start with the
-[contributing guide](./CONTRIBUTING.md).
+(Dependabot also sends its regards.)
+
+Contributors are credited in the app too, on the
+[About page](https://marksight.laramateo.com/about) and the workspace footer.
+Want in? The [contributing guide](./CONTRIBUTING.md) has everything you need,
+and
+[`good first issue`](https://github.com/Rinava/MarkSight/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+is the easiest way to start. PRs here get reviewed quickly instead of
+collecting dust.
 
 ## Author
 
@@ -192,4 +225,4 @@ MarkSight was created and is maintained by
 
 ## License
 
-See [LICENSE](./LICENSE).
+[MIT](./LICENSE).


### PR DESCRIPTION
## Description

Three related docs changes aimed at making the project easier to join:

- **New `CHANGELOG.md`** in [Keep a Changelog](https://keepachangelog.com) format, reconstructed from the full git history: `0.1.0` (the original editor), `1.0.0` (Skill Creator, MCP server, Mermaid, security hardening), and an `Unreleased` section. The repo has no git tags, so version links use commit-SHA compare URLs (verified they resolve).
- **README**: a badge row (CI, contributors, stars, last commit, license, PRs welcome — the shields update from live GitHub data), an About section that tells the actual origin story and links to [the blog post](https://laramateo.com/blog/open-source-markdown-editor), and a Contributors section centered on the people who showed up (Dependabot also sends its regards). The contrib.rocks grid stays, so nobody needs a hand-maintained list.
- **CONTRIBUTING**: the PR checklist now asks user-facing changes to add a line to the Unreleased changelog section, so the changelog maintains itself going forward.

Prose in all three files was reworked to read like a person wrote it: em dashes out of running text, no mechanical boldface in changelog entries, and the README voice matched to the blog post.

## Related issue

No issue. Motivation: the repo had no changelog, and the README undersold the story behind the project. Both matter for attracting contributors.

## Type of change

- [x] 📖 Documentation

## Checklist

- [x] My branch is up to date with `main`
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I updated docs where relevant

Lint/test/build not run locally — the change is markdown-only and touches no source; CI will confirm.