### PR TITLE
feat: add skip-to-content link for keyboard users

### DIFF
--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -233,6 +233,13 @@ export function Workspace() {
   return (
     <TooltipProvider>
       <div className="flex h-dvh flex-col overflow-hidden bg-ms-app font-sans text-ms-ink">
+        <a
+          href="#main-content"
+          className="sr-only rounded-[9px] border border-ms-border-hover bg-ms-surface px-4 py-2 text-[13px] font-semibold text-ms-primary-ink shadow-[var(--ms-shadow-primary)] focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:outline-2 focus:outline-offset-2 focus:outline-ms-primary"
+        >
+          Skip to main content
+        </a>
+
         {/* ── Header ── */}
         <header className="flex h-[58px] flex-none items-center gap-3.5 border-b border-ms-border bg-ms-surface px-[18px]">
           <Logo />
@@ -349,7 +356,11 @@ export function Workspace() {
         </div>
 
         {/* ── Body ── */}
-        <div className="flex min-h-0 flex-1">
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className="flex min-h-0 flex-1 focus:outline-none"
+        >
           <div ref={splitRef} className="flex min-w-0 flex-1">
             {showEditor && (
               <EditorPane
@@ -420,7 +431,7 @@ export function Workspace() {
               onOpenGuide={() => setGuideOpen(true)}
             />
           )}
-        </div>
+        </main>
 
         {/* ── Footer ── */}
         <footer className="flex h-[42px] flex-none items-center gap-3.5 border-t border-ms-border bg-ms-surface px-4 text-[12px] text-ms-muted-3">


### PR DESCRIPTION
## Description

Adds a "Skip to main content" link as the first focusable element in the workspace, so keyboard users can bypass the header and toolbar controls and jump straight to the editor instead of tabbing through all of them on every visit. This addresses WCAG 2.1 "Bypass Blocks" (2.4.1).

The link is visually hidden (`sr-only`) until it receives keyboard focus, then appears at the top-left; it never shows during mouse use and introduces no layout shift. Since the workspace had no `<main>` landmark, the body region is now a `<main id="main-content" tabIndex={-1}>`, which both gives the link a target and adds a proper landmark. Markup + Tailwind classes only, no JS.

## Related issue

Closes #36 

## Type of change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Screenshots / recording

<img width="1850" height="953" alt="Screenshot from 2026-07-09 15-13-29" src="https://github.com/user-attachments/assets/b86bb3a1-3b6b-4531-9555-023f6a917675" />

## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] I tested my change in the browser
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I updated docs where relevant <!-- N/A — no documented behavior changed -->
