### PR TITLE
Add confirmation dialog before clearing document

### DIFF
--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -19,6 +19,15 @@ import { FooterContributors } from "@/components/contributors";
 import { MarkdownToolbar } from "@/components/markdown-toolbar";
 import { MarkdownEditorRef } from "@/components/markdown-editor";
 import { TooltipProvider, Tip } from "@/components/ui/base/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 
 import { EditorPane } from "./editor-pane";
 import { PreviewPane } from "./preview-pane";
@@ -108,6 +117,7 @@ export function Workspace() {
   const [view, setView] = useState<ViewMode>("split");
   const [ratio, setRatio] = useState(50);
   const [guideOpen, setGuideOpen] = useState(false);
+  const [clearDialogOpen, setClearDialogOpen] = useState(false);
 
   const editorRef = useRef<MarkdownEditorRef | null>(null);
   const splitRef = useRef<HTMLDivElement>(null);
@@ -133,7 +143,7 @@ export function Workspace() {
     return () => registerDocumentReplacer(null);
   }, [registerDocumentReplacer, handleValueChange]);
 
-  const handleClear = useCallback(() => {
+  const executeClear = useCallback(() => {
     // Snapshot the pre-clear text so Undo restores it even if the user keeps
     // typing while the toast is still visible.
     const snapshot = value;
@@ -146,7 +156,18 @@ export function Workspace() {
         onClick: () => setValue(snapshot),
       },
     });
+    setClearDialogOpen(false);
   }, [value, setValue, trackClear]);
+
+  // Only interrupt when there's something to lose; empty documents clear
+  // silently.
+  const handleClear = useCallback(() => {
+    if (value.trim() !== "") {
+      setClearDialogOpen(true);
+    } else {
+      executeClear();
+    }
+  }, [value, executeClear]);
 
   const handleReset = useCallback(() => {
     const snapshot = value;
@@ -498,6 +519,25 @@ export function Workspace() {
         </footer>
 
         <MarkdownGuide open={guideOpen} onOpenChange={setGuideOpen} />
+        <Dialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Clear the document?</DialogTitle>
+              <DialogDescription>
+                This removes all content from the editor. You can undo
+                immediately after.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setClearDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button variant="destructive" onClick={executeClear}>
+                Clear
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </TooltipProvider>
   );


### PR DESCRIPTION
## Description
The Clear button was immediately erasing all document content with no confirmation step. A single misclick caused data loss — the only safety net was a brief Undo toast that's easy to miss.

This PR adds a confirmation dialog before clearing. The dialog only appears when the document is non-empty, so clearing an already-empty document stays frictionless. Existing behavior (setValue, trackClear analytics, success toast + Undo) is fully preserved on confirm.

## Related issue
Closes #25

## Type of change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] 🧹 Refactor / chore (no user-facing change)

## Screenshots / recording
**Before:** Click Clear → document erased immediately → toast with Undo appears briefly

**After:** Click Clear → confirmation dialog appears:
> "Clear the document? This removes all content from the editor. You can undo immediately after."
> [Cancel] [Clear]

- Cancel → document unchanged
- Clear → document cleared + existing success toast with Undo

## Checklist
- [x] My branch is up to date with `main`
- [x] `npm run lint` passes (1 pre-existing warning in outline-rail.tsx, unrelated to this PR)
- [x] `npm test` passes (85 tests passing)
- [x] `npm run build` succeeds
- [x] I tested my change in the browser
- [x] My commits follow Conventional Commits
- [ ] I updated docs where relevant