### PR TITLE
security: cap file count and size on local skill-bundle import

### DIFF
--- a/src/lib/skill/__tests__/import.test.ts
+++ b/src/lib/skill/__tests__/import.test.ts
@@ -63,6 +63,28 @@ describe("importSkillBundle ↔ packageSkill round-trip", () => {
       "examples/nested/SKILL.md",
     ]);
   });
+
+  it("rejects bundles with too many files", async () => {
+    const { zipSync, strToU8 } = await import("fflate");
+    const files: Record<string, Uint8Array> = {
+      "SKILL.md": strToU8("---\nname: big\ndescription: x\n---\nbody"),
+    };
+    for (let i = 0; i < 30; i += 1) {
+      files[`references/file-${i}.txt`] = strToU8("x");
+    }
+    await expect(importSkillBundle(zipSync(files))).rejects.toThrow(
+      /too many files/,
+    );
+  });
+
+  it("rejects bundles with an oversized file", async () => {
+    const { zipSync, strToU8 } = await import("fflate");
+    const bytes = zipSync({
+      "SKILL.md": strToU8("---\nname: big\ndescription: x\n---\nbody"),
+      "references/huge.bin": new Uint8Array(1_000_001),
+    });
+    await expect(importSkillBundle(bytes)).rejects.toThrow(/too large/);
+  });
 });
 
 describe("parseGitHubUrl", () => {

--- a/src/lib/skill/import.ts
+++ b/src/lib/skill/import.ts
@@ -32,15 +32,36 @@ export function importSkillMd(text: string): ImportedSkill {
 
 const SKILL_MD_RE = /(^|\/)SKILL\.md$/;
 
+const MAX_BUNDLE_FILES = 30;
+const MAX_FILE_BYTES = 1_000_000;
+
+function isBundleEntry(name: string): boolean {
+  return !name.endsWith("/") && !name.split("/").includes("__MACOSX");
+}
+
 export async function importSkillBundle(
   bytes: Uint8Array,
 ): Promise<ImportedSkill> {
   const { unzipSync, strFromU8 } = await import("fflate");
-  const entries = unzipSync(bytes);
 
-  const paths = Object.keys(entries).filter(
-    (p) => !p.endsWith("/") && !p.split("/").includes("__MACOSX"),
-  );
+  let fileCount = 0;
+  const entries = unzipSync(bytes, {
+    filter(file) {
+      if (!isBundleEntry(file.name)) return false;
+      fileCount += 1;
+      if (fileCount > MAX_BUNDLE_FILES) {
+        throw new Error(
+          `Bundle has too many files to import (limit ${MAX_BUNDLE_FILES}).`,
+        );
+      }
+      if (file.originalSize > MAX_FILE_BYTES) {
+        throw new Error(`"${file.name}" is too large to import (limit 1 MB).`);
+      }
+      return true;
+    },
+  });
+
+  const paths = Object.keys(entries);
   const skillMdPath = paths
     .filter((p) => SKILL_MD_RE.test(p))
     // Prefer the shallowest SKILL.md (the skill root, not a nested example).


### PR DESCRIPTION
## Description

The local `.skill`/`.zip` import path (`importSkillBundle`) ran `unzipSync` on user-supplied bytes with no entry-count or per-file size limits, so a hostile zip (zip-bomb) could exhaust memory. The remote GitHub-fetch path already caps at 30 files / 1 MB each. This closes the asymmetry by applying the same caps to the local path.

Caps are enforced via fflate's `filter`, which runs before each entry is decompressed — oversized or excess entries are rejected without being inflated, and a clear error surfaces in the import toast. Directory and `__MACOSX` entries are skipped (not counted), matching the existing bundle-entry filtering.

Note: the guard is header/count-based (bounds decompression to ≤30 files × ≤1 MB), matching the remote path's caps. Consistent with the issue's low, client-side-only severity.

## Related issue

Closes #83

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] I added tests (too-many-files and oversized-file both reject)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I updated docs where relevant <!-- N/A -->
