### PR TITLE
Fix docs drift: proxy.ts rename, gemini-flash-latest default, export filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ I shipped. The longer version of that story is on my blog:
 - **Smart toolbar** — context-aware formatting that detects and toggles existing markdown
 - **Keyboard shortcuts** — bold (⌘B), italic (⌘I), strikethrough (⌘U), link (⌘K), inline code (⌘`), headings (⌘⇧1–3), lists, and more
 - **Document outline** — auto-generated, clickable heading navigation that scrolls the preview
-- **Export** — download the raw Markdown source or styled HTML, print to PDF, or preview the HTML in a new tab
+- **Export** — download the raw Markdown source or styled HTML, print to PDF, or preview the HTML in a new tab; set a custom file name before exporting
 - **Skill Creator** — package your document as an [Agent Skill](https://code.claude.com/docs/en/skills) (⌘⇧K) that Claude and other AIs can receive: copy the generated `SKILL.md` or download a ready-to-install `.skill` bundle. Import existing skills from a `.skill`/`.zip` file or straight from GitHub-hosted marketplaces (like [anthropics/skills](https://github.com/anthropics/skills)), modify them, and re-export with bundled files preserved
 - **GitHub-flavored markdown** — tables, task lists, strikethrough (via `remark-gfm`)
 - **Syntax highlighting** — fenced code blocks rendered with Prism

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,7 @@ const nextConfig: NextConfig = {
     ],
   },
   // Static security headers. The per-request Content-Security-Policy (with a
-  // nonce) is set in middleware.ts.
+  // nonce) is set in proxy.ts.
   async headers() {
     return [
       {

--- a/src/app/api/skill/improve/route.ts
+++ b/src/app/api/skill/improve/route.ts
@@ -8,7 +8,7 @@ import { deriveSkillMeta } from "@/lib/skill/derive";
  * AI refinement for skill metadata. Two provider paths, checked in order:
  *
  * 1. `GOOGLE_GENERATIVE_AI_API_KEY` → direct Gemini (free AI Studio tier;
- *    `SKILL_AI_MODEL` is a bare Gemini id, default `gemini-3-flash`).
+ *    `SKILL_AI_MODEL` is a bare Gemini id, default `gemini-flash-latest`).
  * 2. `AI_GATEWAY_API_KEY` / `VERCEL_OIDC_TOKEN` → Vercel AI Gateway (plain
  *    "provider/model" slug, default `anthropic/claude-haiku-4.5`).
  *


### PR DESCRIPTION
Closes #127. Three small drift fixes: (1) next.config.ts's CSP-nonce comment pointed to middleware.ts, which was renamed to src/proxy.ts under Next 16; (2) the header comment in src/app/api/skill/improve/route.ts claimed the default Gemini model is gemini-3-flash, but the actual default (and .env.example) is gemini-flash-latest; (3) README.md's Export bullet didn't mention the custom export-filename field added in #113.