### PR TITLE
perf: lazy-load images in markdown preview

### DIFF
--- a/src/components/markdown-preview.tsx
+++ b/src/components/markdown-preview.tsx
@@ -128,6 +128,12 @@ export const MarkdownPreview = memo(function MarkdownPreview({
               </a>
             );
           },
+          img({ alt, ...props }) {
+            // Markdown src is an arbitrary user URL, so next/image's remote-domain
+            // allowlist can't cover it — use a plain lazy <img>.
+            // eslint-disable-next-line @next/next/no-img-element
+            return <img {...props} alt={alt ?? ""} loading="lazy" decoding="async" />;
+          },
           code({ className: codeClassName, children }) {
             const match = /language-(\w+)/.exec(codeClassName ?? "");
 


### PR DESCRIPTION
## Summary

Adds a custom image renderer to the Markdown preview to improve loading performance.

### Changes
- Add a custom `img` renderer in `MarkdownPreview`
- Set `loading="lazy"` for off-screen images
- Set `decoding="async"` for asynchronous image decoding
- Preserve existing image props (`src`, `title`, etc.) by spreading the props
- Default missing `alt` text to `""` for accessibility
- Keep using the native `<img>` element since Markdown images can reference arbitrary user-supplied URLs, making `next/image` unsuitable

## Testing

- [x] `npm run lint`
- [x] `npm run build`