### PR TITLE
#18-Show error toast when clipboard copy fails

### DIFF
--- a/src/components/markdown-preview.tsx
+++ b/src/components/markdown-preview.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { toast } from "sonner";
 import { memo, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -43,6 +43,7 @@ function CodeBlock({
       }, 2000);
     } catch (err) {
       console.error("Failed to copy:", err);
+      toast.error("Couldn't copy to clipboard");
     }
   }
   useEffect(() => {


### PR DESCRIPTION
<!--
Thanks for contributing to MarkSight! 💛
Please fill out the sections below. Remove any that don't apply.
-->

## Description
This PR adds a user-visible error toast when copying a code block fails.

### Changes
- Import `toast` from `sonner`
- Display an error toast when `navigator.clipboard.writeText()` rejects
- Preserve the existing success behavior (copy + checkmark)

## Related issue
Closes #18

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My branch is up to date with `main`
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] I tested my change in the browser
